### PR TITLE
Makes it so broken links will redirect to /commune/

### DIFF
--- a/TweetCommuneWeb/urls.py
+++ b/TweetCommuneWeb/urls.py
@@ -1,7 +1,11 @@
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
+from django.shortcuts import redirect
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('commune/', include('tweet_commune.urls'))
+    path('commune/', include('tweet_commune.urls')),
+    re_path(r'^.*/', RedirectView.as_view(url='/commune/', permanent=False), name='index'),
+    path('', RedirectView.as_view(url='/commune/', permanent=False), name='index')
 ]


### PR DESCRIPTION
If a user for example types in /asdasdda/ it'll now redirect
instead of throwing a 404