### PR TITLE
Update README with instructions on setting up a local SQLite DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Now clone the repository to your local machine. In the root of the repository, i
 pip install -r requirements.txt
 ```
 
+If you're having issues creating a Postgres database try copying the
+[original SQLite configuration](https://choosealicense.com/licenses/mit/).
+
 Make the necessary database migrations by running:
 
 ```bash


### PR DESCRIPTION
Setting up postgres is hard and using SQLite is way easier for
testing. This commit adds instructions for the README to tell users
how to do that.