### PR TITLE
Stop filter from double flagging submissions

### DIFF
--- a/tweet_commune/management/commands/send_tweet.py
+++ b/tweet_commune/management/commands/send_tweet.py
@@ -13,27 +13,13 @@ class Command(BaseCommand):
 
     help = "Post the top submission"
 
-
-    @staticmethod
-    def get_action():
-        raffle = Raffle(multiplier=5)
-        while Submission.queue.length() > 0:
-            submission = raffle.choices(Submission.queue.all())[0]
-            action = SubmissionActions(submission)
-            # Ensure Submission is valid
-            if action.validate():
-                return action
-            else:
-                # If invalid, flag
-                action.flag()
-        # Return None if queue is empty
-        return None
-
     def handle(self, *args, **options):
         try:
-            action = Command.get_action()
-            if action:
-                action.post()
+            raffle = Raffle(multiplier=5)
+            submission = raffle.choices(Submission.queue.all())[0]
+            if submission:
+                actions = SubmissionActions(submission)
+                actions.post()
             else:
                 TweetLogger.empty_queue()
         except Exception as e:

--- a/tweet_commune/management/commands/validate_submissions.py
+++ b/tweet_commune/management/commands/validate_submissions.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.core.management.base import BaseCommand
 
 from tweet_commune.submission_actions import SubmissionActions
@@ -13,8 +15,29 @@ class Command(BaseCommand):
 
     help = "Validate all Submissions in queue"
 
+    def add_arguments(self, parser):
+        # Length (in days) of submissions to filter
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=0,
+            help='Filters all submissions created in the past n days.',
+        )
+
+    _ONE_DAY = datetime.timedelta(days=1)
+
     def handle(self, *args, **options):
-        for submission in Submission.queue.all():
+        days = 1
+        if options['days']:
+            days = options['days']
+        # 1 full day is the minimum allowed
+        if days < 1:
+            raise Exception("--days must be greater than 0")
+        # Get all submissions created within the past n days
+        from_date = datetime.date.today() - datetime.timedelta(days=options['days'])
+        to_filter = Submission.objects.all().filter(date_created__gte=from_date)
+        # Check each submission against the filter
+        for submission in to_filter:
             action = SubmissionActions(submission)
             if not action.validate():
                 action.flag()


### PR DESCRIPTION
Prior to this update, it was impossible to unflag a submission caught in the filter because each time the filter job ran it would get flagged again and send_tweet checks each submission against the filter before posting. This update rolls back send_tweet so that it no longer checks against the filter. It also adds a '--days' parameter to validate_submissions so that submissions can be filtered based on how many days old they are to prevent being flagged multiple times.